### PR TITLE
Improve configuration handling and fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Before installation, consider setting up some API keys if you so wish.
 
 To get album covers I try 3 different APIs (Last.fm, MusicBrains, and Discogs), two of which require API keys (Last.fm and discogs). Last.fm is the preferred API. 
 
-To set up your API keys, you will want to rename `covers2colors/keys_template.json` to `covers2colors/keys.json` and add in your API keys in there. Once the file is renamed the package will assume it contains valid api keys and will attempt to use them.
+To set up your API keys, you can rename `covers2colors/keys_template.json` to `covers2colors/keys.json` and add your API keys in there. If this file is missing, the package will look for the environment variables `LASTFM_API_KEY` and `DISCOGS_TOKEN`.
 
 If you would rather not bother getting any API keys, artwork will attempt to be fetched from MusicBrainz only. things should still work fine, although the MusicBrains API can be slow. I've also noticed that the color on some album covers appear muted on Discogs and MusicBrains.
 
@@ -89,7 +89,7 @@ When running the ``generate_cmap`` or the ``generate_optimal_cmap`` methods the 
 capture the resulting hexcodes from the colormap and store them as an attribute.
 
 
-    from cover2colors import CoverColors
+    from covers2colors import CoverColors
 
     covercolors = CoverColors('Nirvana', 'Nevermind')
     covercolors.generate_cmap(n_colors=4, random_state=42)

--- a/covers2colors/__init__.py
+++ b/covers2colors/__init__.py
@@ -1,4 +1,4 @@
 from .convert import CoverColors
 from .album_art import get_best_cover_art_url
 
-__version__ = "0.2.3"
+__version__ = "0.1"

--- a/covers2colors/convert.py
+++ b/covers2colors/convert.py
@@ -1,4 +1,4 @@
-import colorsys, json, os, pkg_resources
+import colorsys
 from urllib.error import HTTPError
 from urllib.error import URLError
 from urllib.request import urlopen
@@ -11,7 +11,7 @@ from PIL import Image
 from sklearn.cluster import KMeans
 from matplotlib.colors import ListedColormap
 from sklearn.cluster import MiniBatchKMeans
-from .album_art import get_best_cover_art_url
+from .album_art import get_best_cover_art_url, load_api_keys
 from scipy.spatial.distance import pdist, squareform
 
 class CoverColors:
@@ -36,13 +36,17 @@ class CoverColors:
         """
         Initializes the CoverColors object by fetching the cover art and converting it to a numpy array of RGB values.
         """
-        api_key = None
-        keys_path = pkg_resources.resource_filename('covers2colors', 'keys.json')
-        with open(keys_path, 'r') as f:
-            config = json.load(f)
-            api_key = config['lastfm']['api_key']
+        api_key, discogs_token = load_api_keys()
 
-        cover_art_url = get_best_cover_art_url(artist, album, api_key = api_key)
+        cover_art_url = get_best_cover_art_url(
+            artist,
+            album,
+            api_key=api_key,
+            user_token=discogs_token,
+        )
+        if not cover_art_url:
+            raise ValueError(f"Cover art not found for {artist} - {album}")
+
         self.image_path = cover_art_url
         self.album = album
         try:

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    package_data={
-        'covers2colors': ['keys.json'], 
-    },
     python_requires='>=3.6',
     install_requires=[
         "matplotlib",


### PR DESCRIPTION
## Summary
- support loading API keys lazily and from environment variables
- guard against missing URLs and uninitialized variables
- update docs and imports
- sync version numbers
- drop keys from package_data

## Testing
- `python -m py_compile covers2colors/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6844fb0d41f08323822b4488704b375b