### PR TITLE
Add hue flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Clone the repo, navigate inside it and use ``pip install .``
 
 For detailed instructions and command line usage see [USAGE.md](USAGE.md).
 You can enter the artist and album without quotes by placing a dash between
-them, e.g. ``coverpalette artist - album``.  You can also list saved palettes
-with ``coverpalette list``.  Run ``coverpalette list --pdf`` to open a PDF
-showing the stored palettes.
+them, e.g. ``coverpalette artist - album``. Add ``--hue`` to select colors with
+maximal hue separation.  You can also list saved palettes with
+``coverpalette list``.  Run ``coverpalette list --pdf`` to open a PDF showing
+the stored palettes.
 
 ### API access to album covers
 Before installation, consider setting up some API keys if you so wish.
@@ -105,6 +106,24 @@ Output:
 
 
     ['#0ea1c1', '#456a78', '#0269ae', '#091a2d']
+
+You can convert these hexcodes to hue, saturation and brightness (value) using
+``hexcodes_to_hsv``:
+
+```python
+hsv_colors = coverpalette.hexcodes_to_hsv()
+print(hsv_colors)
+```
+
+If you want a palette whose hues are maximally separated you can call
+``generate_hue_distinct_optimal_cmap`` which works similarly to
+``generate_distinct_optimal_cmap`` but focuses only on hue differences.
+
+```python
+distinct_colors, distinct_cmap = coverpalette.generate_hue_distinct_optimal_cmap(
+    n_distinct_colors=4
+)
+```
 
 ### Saving and loading palettes
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -15,6 +15,7 @@ single dash (`-`).
 ```bash
 coverpalette artist - album -n 5       # preview then optionally save
 coverpalette artist - album -n 5 --save  # save directly
+coverpalette artist - album -n 5 --hue   # maximize hue separation
 ```
 
 This prints the hex codes of the palette. Palettes saved via the command line

--- a/covers2colors/cli.py
+++ b/covers2colors/cli.py
@@ -75,6 +75,11 @@ def main() -> None:
     parser.add_argument("-n", "--n-colors", type=int, default=4, help="Number of colors")
     parser.add_argument("--random-state", type=int, default=None, help="Random seed")
     parser.add_argument(
+        "--hue",
+        action="store_true",
+        help="Maximize hue separation when selecting colors",
+    )
+    parser.add_argument(
         "--save",
         action="store_true",
         help="Save without previewing the palette",
@@ -82,9 +87,14 @@ def main() -> None:
     args = parser.parse_args()
 
     palette = CoverPalette(args.artist, args.album)
-    _, cmap = palette.generate_distinct_optimal_cmap(
-        n_distinct_colors=args.n_colors, random_state=args.random_state
-    )
+    if args.hue:
+        _, cmap = palette.generate_hue_distinct_optimal_cmap(
+            n_distinct_colors=args.n_colors, random_state=args.random_state
+        )
+    else:
+        _, cmap = palette.generate_distinct_optimal_cmap(
+            n_distinct_colors=args.n_colors, random_state=args.random_state
+        )
     print("Hexcodes:", " ".join(palette.hexcodes))
 
     if args.save:


### PR DESCRIPTION
## Summary
- add `--hue` flag to `coverpalette` command
- document hue flag in README and USAGE

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465ae1a600832399a0fcc146968ff1